### PR TITLE
Replace ampersand in title with 'and' to match ONS style

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -6,7 +6,7 @@ info:
   to include new or different codes. The meaning of a code should not change over
   time, but new codes may be created where new meaning is required."
   version: "1.0.0"
-  title: "Explore codes & lists"
+  title: "Explore codes and lists"
   license:
     name: "Open Government Licence v3.0"
     url: "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"


### PR DESCRIPTION
### What

Replace ampersand in the swagger spec title with 'and' so that it fits ONS house styles (i.e. not using symbols but words instead).

### How to review

Check the `swagger.yaml`diff is correct.

### Who can review

Anyone.
