### PR TITLE
Update response models to satisfy API standards

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,10 @@ test:
 	go test -cover $(shell go list ./... | grep -v /vendor/)
 
 debug:
-	HUMAN_LOG=1 go run cmd/dp-code-list-api/main.go
+	HUMAN_LOG=1 go run -race cmd/dp-code-list-api/main.go
 
 acceptance:
-	HUMAN_LOG=1 NEO4J_CODE_LIST_LABEL=code_list_acceptance go run cmd/dp-code-list-api/main.go
+	HUMAN_LOG=1 NEO4J_CODE_LIST_LABEL=code_list_acceptance go run -race cmd/dp-code-list-api/main.go
 
-.PHONY: test build debug
+.PHONY: test build debug acceptance
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The endpoint `/healthcheck` checks the connection to the database and returns on
 
 | Environment variable        | Default                                | Description
 | --------------------------- | ---------------------------------------| -----------
-| BIND_ADDR                   | :22000                                 | The host and port to bind to
+| BIND_ADDR                   | :22400                                 | The host and port to bind to
 | NEO4J_BIND_ADDRESS          | bolt://localhost:7687                  | The address of the neo4j database to retrieve dataset data from
 | NEO4J_POOL_SIZE             | 5                                      | The number of neo4j connections to pool
 | NEO4J_CODE_LIST_LABEL       | code_list                              | The code list node label identifier in neo4j

--- a/models/code.go
+++ b/models/code.go
@@ -2,10 +2,10 @@ package models
 
 // CodeResults contains an array of codes which can be paginated
 type CodeResults struct {
+	Items      []Code `json:"items"`
 	Count      int    `json:"count"`
 	Offset     int    `json:"offset"`
 	Limit      int    `json:"limit"`
-	Items      []Code `json:"items"`
 	TotalCount int    `json:"total_count"`
 }
 
@@ -21,5 +21,6 @@ type Code struct {
 // CodeLinks contains links for a code resource
 type CodeLinks struct {
 	CodeList Link `json:"code_list"`
+	Datasets Link `json:"datasets"`
 	Self     Link `json:"self"`
 }

--- a/models/codelist.go
+++ b/models/codelist.go
@@ -2,11 +2,11 @@ package models
 
 // CodeListResults contains an array of code lists which can be paginated
 type CodeListResults struct {
+	Items      []CodeList `json:"items"`
 	Count      int        `json:"count"`
 	Offset     int        `json:"offset"`
 	Limit      int        `json:"limit"`
-	Items      []CodeList `json:"items"`
-	TotalCount int        `json:"number_of_results"`
+	TotalCount int        `json:"total_count"`
 }
 
 // CodeList containing links to all possible codes

--- a/models/dataset.go
+++ b/models/dataset.go
@@ -3,8 +3,11 @@ package models
 // Datasets represents the model returned from the api datasets
 // endpoint
 type Datasets struct {
-	Items           []Dataset `json:"datasets"`
-	NumberOfResults int       `json:"number_of_results"`
+	Items      []Dataset `json:"items"`
+	Count      int       `json:"count"`
+	Offset     int       `json:"offset"`
+	Limit      int       `json:"limit"`
+	TotalCount int       `json:"total_count"`
 }
 
 // Dataset represents an individual model dataset

--- a/models/editions.go
+++ b/models/editions.go
@@ -2,8 +2,11 @@ package models
 
 // Editions represents the editions response model
 type Editions struct {
-	Items           []Edition `json:"items"`
-	NumberOfResults int       `json:"number_of_results"`
+	Items      []Edition `json:"items"`
+	Count      int       `json:"count"`
+	Offset     int       `json:"offset"`
+	Limit      int       `json:"limit"`
+	TotalCount int       `json:"total_count"`
 }
 
 // Edition represents a single edition response model

--- a/store/datasets_test.go
+++ b/store/datasets_test.go
@@ -83,7 +83,7 @@ func TestCodeDatasets(t *testing.T) {
 			datasets, err := neo.GetCodeDatasets(context.Background(), "my-code-list-id", "2017", "my-code")
 			Convey("then the datasets are returned correctly", func() {
 				So(err, ShouldBeNil)
-				So(datasets.NumberOfResults, ShouldEqual, 2)
+				So(datasets.Count, ShouldEqual, 2)
 
 				item1 := datasets.Items[0]
 				So(item1.DimensionLabel, ShouldEqual, "Overall index")

--- a/store/neo4j.go
+++ b/store/neo4j.go
@@ -297,7 +297,9 @@ func (n *NeoDataStore) GetEditions(ctx context.Context, codeListID string) (*mod
 		return nil, datastore.NOT_FOUND
 	}
 
-	editions.NumberOfResults = len(editions.Items)
+	editions.Count = len(editions.Items)
+	editions.Limit = len(editions.Items)
+	editions.TotalCount = len(editions.Items)
 
 	return editions, nil
 }
@@ -396,6 +398,9 @@ func (n *NeoDataStore) GetCodes(ctx context.Context, codeListID, edition string)
 			Links: models.CodeLinks{
 				Self: models.Link{
 					Href: fmt.Sprintf("/code-lists/%s/editions/%s/codes/%s", codeListID, edition, codeValue),
+				},
+				Datasets: models.Link{
+					Href: fmt.Sprintf("/code-lists/%s/editions/%s/codes/%s/datasets", codeListID, edition, codeValue),
 				},
 				CodeList: models.Link{
 					Href: fmt.Sprintf("/code-lists/%s", codeListID),
@@ -533,7 +538,9 @@ func (n *NeoDataStore) GetCodeDatasets(ctx context.Context, codeListID, edition,
 		return nil, datastore.NOT_FOUND
 	}
 
-	datasetsModel.NumberOfResults = len(datasetsModel.Items)
+	datasetsModel.TotalCount = len(datasetsModel.Items)
+	datasetsModel.Count = len(datasetsModel.Items)
+	datasetsModel.Limit = len(datasetsModel.Items)
 
 	return datasetsModel, err
 }

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -22,9 +22,15 @@ parameters:
     in: path
     type: string
     required: true
+  edition:
+    name: edition
+    description: "The edition of the code list"
+    in: path
+    type: string
+    required: true
   codeId:
     name: code_id
-    description: "The ID of the Code within a code list"
+    description: "The ID of the code within a code list"
     in: path
     type: string
     required: true
@@ -34,7 +40,7 @@ paths:
       tags:
       - "Code List"
       summary: "Get a list of code lists"
-      description: "Get a set of codes lists containing information about dimensions which are used for all datasets at the ONS"
+      description: "Get a set of code lists containing information about dimensions which are used for all datasets at the ONS"
       produces:
       - "application/json"
       responses:
@@ -42,8 +48,6 @@ paths:
           description: "A Json message containing a set of code lists"
           schema:
             $ref: '#/definitions/CodeLists'
-        400:
-          description: "Missing parameters within request"
         500:
           description: "Failed to process the request due to an internal error"
   /code-lists/{id}:
@@ -65,14 +69,54 @@ paths:
           description: "Code list not found"
         500:
           description: "Failed to process the request due to an internal error"
-  /code-lists/{id}/codes:
+  /code-lists/{id}/editions:
+    get:
+      tags:
+      - "Code List"
+      summary: "Get a list of editions"
+      description: "Get a list of editions associated with a code list"
+      parameters:
+      - $ref: '#/parameters/id'
+      produces:
+      - "application/json"
+      responses:
+        200:
+          description: "Json object containing an array of editions"
+          schema:
+            $ref: '#/definitions/Editions'
+        404:
+          description: "Code list not found"
+        500:
+          description: "Failed to process the request due to an internal error"
+  /code-lists/{id}/editions/{edition}:
+    get:
+      tags:
+      - "Code List"
+      summary: "Get an edition"
+      description: "Get information about an edition of a code list"
+      parameters:
+      - $ref: '#/parameters/id'
+      - $ref: '#/parameters/edition'
+      produces:
+      - "application/json"
+      responses:
+        200:
+          description: "Json object containing information about the code list"
+          schema:
+            $ref: '#/definitions/Edition'
+        404:
+          description: "Edition not found"
+        500:
+          description: "Failed to process the request due to an internal error"
+  /code-lists/{id}/editions/{edition}/codes:
     get:
       tags:
        - "Code List"
-      summary: "Get a list of all codes within a code list"
-      description: "Get a list of codes within a code list type"
+      summary: "Get a list of all codes within a code list edition"
+      description: "Get a list of codes within a code list edition"
       parameters:
       - $ref: '#/parameters/id'
+      - $ref: '#/parameters/edition'
       produces:
       - "application/json"
       responses:
@@ -81,10 +125,10 @@ paths:
           schema:
             $ref: '#/definitions/Codes'
         404:
-          description: "Code list not found"
+          description: "Edition not found"
         500:
           description: "Failed to process the request due to an internal error"
-  /code-lists/{id}/codes/{code_id}:
+  /code-lists/{id}/editions/{edition}/codes/{code_id}:
     get:
       tags:
        - "Code List"
@@ -92,6 +136,7 @@ paths:
       description: "Get information about a code within a code list"
       parameters:
       - $ref: '#/parameters/id'
+      - $ref: '#/parameters/edition'
       - $ref: '#/parameters/codeId'
       produces:
       - "application/json"
@@ -99,9 +144,30 @@ paths:
         200:
           description: "Get in depth information about a code"
           schema:
-            $ref: '#/definitions/CodeInformation'
+            $ref: '#/definitions/Code'
         404:
           description: "Code list or code not found"
+        500:
+          description: "Failed to process the request due to an internal error"
+  /code-lists/{id}/editions/{edition}/codes/{code_id}/datasets:
+    get:
+      tags:
+       - "Code List"
+      summary: "Get datasets"
+      description: "Get the datasets that use this code"
+      parameters:
+      - $ref: '#/parameters/id'
+      - $ref: '#/parameters/edition'
+      - $ref: '#/parameters/codeId'
+      produces:
+      - "application/json"
+      responses:
+        200:
+          description: "Get the datasets that use this code"
+          schema:
+            $ref: '#/definitions/Datasets'
+        404:
+          description: "Code not found"
         500:
           description: "Failed to process the request due to an internal error"
 definitions:
@@ -128,13 +194,16 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/CodeList'
-      number_of_results:
-        type: integer
-        description: "The number of results available"
+      count:
+        $ref: '#/definitions/Count'
+      total_count:
+        $ref: '#/definitions/TotalCount'
+      limit:
+        $ref: '#/definitions/Limit'
   Code:
     type: object
     properties:
-      code:
+      id:
         type: string
         description: "The value of a code"
       label:
@@ -147,6 +216,8 @@ definitions:
             $ref: '#/definitions/Href'
           code_list:
             $ref: '#/definitions/Href'
+          datasets:
+            $ref: '#/definitions/Href'
   Codes:
     type: object
     properties:
@@ -154,21 +225,82 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/Code'
-      number_of_results:
-              type: integer
-              description: "The number of results available"
-  CodeInformation:
+      count:
+        $ref: '#/definitions/Count'
+      total_count:
+        $ref: '#/definitions/TotalCount'
+      limit:
+        $ref: '#/definitions/Limit'
+  Edition:
     type: object
     properties:
-      id:
+      edition:
         type: string
-        description: "The id for the code"
-      name:
+        description: "The edition"
+      label:
         type: string
-        description: "The name for the code"
-      information:
+        description: "A label used by the edition"
+      links:
         type: object
-        description: "Additional information about the code"
+        properties:
+          self:
+            $ref: '#/definitions/Href'
+          codes:
+            $ref: '#/definitions/Href'
+          editions:
+            $ref: '#/definitions/Href'
+  Editions:
+    type: object
+    properties:
+      items:
+        type: array
+        items:
+          $ref: '#/definitions/Edition'
+      count:
+        $ref: '#/definitions/Count'
+      total_count:
+        $ref: '#/definitions/TotalCount'
+      limit:
+        $ref: '#/definitions/Limit'
+  Dataset:
+    type: object
+    properties:
+      dataset_id:
+        type: string
+        description: "The ID of the dataset"
+      dimension_label:
+        type: string
+        description: "The code label used by this dataset"
+      editions:
+        items:
+          type: array
+          items:
+            $ref: '#/definitions/DatasetEdition'
+  DatasetEdition:
+    type: object
+    properties:
+      links:
+        type: object
+        properties:
+          self:
+            $ref: '#/definitions/Href'
+          dataset_dimension:
+            $ref: '#/definitions/Href'
+          latest_version:
+            $ref: '#/definitions/Href'
+  Datasets:
+    type: object
+    properties:
+      items:
+        type: array
+        items:
+          $ref: '#/definitions/Dataset'
+      count:
+        $ref: '#/definitions/Count'
+      total_count:
+        $ref: '#/definitions/TotalCount'
+      limit:
+        $ref: '#/definitions/Limit'
   Href:
     type: object
     properties:
@@ -178,3 +310,13 @@ definitions:
       href:
         type: string
         description: "The URL to the resource"
+  Count:
+    type: string
+    description: "The number of results returned in this response"
+  TotalCount:
+    type: string
+    description: "The total number of results available"
+  Limit:
+    type: string
+    description: "The limit applied to the number of results returned"
+

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -154,7 +154,7 @@ paths:
       tags:
        - "Code List"
       summary: "Get datasets"
-      description: "Get the datasets that use this code"
+      description: "Get a list of the datasets that use this code"
       parameters:
       - $ref: '#/parameters/id'
       - $ref: '#/parameters/edition'
@@ -163,7 +163,7 @@ paths:
       - "application/json"
       responses:
         200:
-          description: "Get the datasets that use this code"
+          description: "Get a list of the datasets that use this code"
           schema:
             $ref: '#/definitions/Datasets'
         404:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -265,9 +265,11 @@ definitions:
   Dataset:
     type: object
     properties:
-      dataset_id:
-        type: string
-        description: "The ID of the dataset"
+      links:
+        type: object
+        properties:
+          self:
+            $ref: '#/definitions/Href'
       dimension_label:
         type: string
         description: "The code label used by this dataset"


### PR DESCRIPTION
### What

* Update /datasets response model to use `items` instead of `datasets`
* Add link to /datasets from code endpoint
* Update swagger spec for anticipated /datasets response model

### How to review

Review changes / test

### Who can review

Anyone
