### PR TITLE
Removed go-ns/rchttp dependency from vendor.json. No reference in project

### DIFF
--- a/vendor/github.com/jtolds/gls/stack_tags.go
+++ b/vendor/github.com/jtolds/gls/stack_tags.go
@@ -51,22 +51,56 @@ func addStackTag(tag uint, context_call func()) {
 
 // these private methods are named this horrendous name so gopherjs support
 // is easier. it shouldn't add any runtime cost in non-js builds.
+
+//go:noinline
 func github_com_jtolds_gls_markS(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_mark0(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_mark1(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_mark2(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_mark3(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_mark4(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_mark5(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_mark6(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_mark7(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_mark8(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_mark9(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_markA(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_markB(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_markC(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_markD(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_markE(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_markF(tag uint, cb func()) { _m(tag, cb) }
 
 func _m(tag_remainder uint, cb func()) {

--- a/vendor/github.com/smartystreets/goconvey/convey/assertions.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/assertions.go
@@ -16,6 +16,7 @@ var (
 	ShouldBeTrue         = assertions.ShouldBeTrue
 	ShouldBeFalse        = assertions.ShouldBeFalse
 	ShouldBeZeroValue    = assertions.ShouldBeZeroValue
+	ShouldNotBeZeroValue = assertions.ShouldNotBeZeroValue
 
 	ShouldBeGreaterThan          = assertions.ShouldBeGreaterThan
 	ShouldBeGreaterThanOrEqualTo = assertions.ShouldBeGreaterThanOrEqualTo

--- a/vendor/github.com/smartystreets/goconvey/convey/doc.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/doc.go
@@ -202,7 +202,7 @@ func SuppressConsoleStatistics() {
 	reporting.SuppressConsoleStatistics()
 }
 
-// ConsoleStatistics may be called at any time to print assertion statistics.
+// PrintConsoleStatistics may be called at any time to print assertion statistics.
 // Generally, the best place to do this would be in a TestMain function,
 // after all tests have been run. Something like this:
 //

--- a/vendor/github.com/smartystreets/goconvey/convey/reporting/init.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/reporting/init.go
@@ -56,7 +56,7 @@ var (
 	dotError        = "E"
 	dotSkip         = "S"
 	errorTemplate   = "* %s \nLine %d: - %v \n%s\n"
-	failureTemplate = "* %s \nLine %d:\n%s\n"
+	failureTemplate = "* %s \nLine %d:\n%s\n%s\n"
 )
 
 var (
@@ -71,7 +71,7 @@ var consoleStatistics = NewStatisticsReporter(NewPrinter(NewConsole()))
 func SuppressConsoleStatistics() { consoleStatistics.Suppress() }
 func PrintConsoleStatistics()    { consoleStatistics.PrintSummary() }
 
-// QuiteMode disables all console output symbols. This is only meant to be used
+// QuietMode disables all console output symbols. This is only meant to be used
 // for tests that are internal to goconvey where the output is distracting or
 // otherwise not needed in the test output.
 func QuietMode() {

--- a/vendor/github.com/smartystreets/goconvey/convey/reporting/printer.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/reporting/printer.go
@@ -30,11 +30,14 @@ func (self *Printer) format(message string, values ...interface{}) string {
 	if len(values) == 0 {
 		formatted = self.prefix + message
 	} else {
-		formatted = self.prefix + fmt.Sprintf(message, values...)
+		formatted = self.prefix + fmt_Sprintf(message, values...)
 	}
 	indented := strings.Replace(formatted, newline, newline+self.prefix, -1)
 	return strings.TrimRight(indented, space)
 }
+
+// Extracting fmt.Sprintf to a separate variable circumvents go vet, which, as of go 1.10 is run with go test.
+var fmt_Sprintf = fmt.Sprintf
 
 func (self *Printer) Indent() {
 	self.prefix += pad

--- a/vendor/github.com/smartystreets/goconvey/convey/reporting/problems.go
+++ b/vendor/github.com/smartystreets/goconvey/convey/reporting/problems.go
@@ -53,7 +53,7 @@ func (self *problem) showFailures() {
 			self.out.Println("\nFailures:\n")
 			self.out.Indent()
 		}
-		self.out.Println(failureTemplate, f.File, f.Line, f.Failure)
+		self.out.Println(failureTemplate, f.File, f.Line, f.Failure, f.StackTrace)
 	}
 }
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -105,6 +105,12 @@
 			"revisionTime": "2019-03-01T13:55:03Z"
 		},
 		{
+			"checksumSHA1": "L4B1AA6AKWscHCZc02qk2SQU65k=",
+			"path": "github.com/ONSdigital/go-ns/rchttp",
+			"revision": "1c0a788c5b8e666c674540fc0881960857d73b3b",
+			"revisionTime": "2019-01-17T11:52:14Z"
+		},
+		{
 			"checksumSHA1": "GQdzMpAMb42KQQ/GsJFSRU5dj1Y=",
 			"path": "github.com/ONSdigital/go-ns/server",
 			"revision": "1c0a788c5b8e666c674540fc0881960857d73b3b",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,7 +3,7 @@
 	"ignore": "test",
 	"package": [
 		{
-			"checksumSHA1": "4qY6/7BWqggHkEI9og6As2aZRE0=",
+			"checksumSHA1": "52z+3ABu6w+3UiTs8nk9JjnWPco=",
 			"path": "github.com/ONSdigital/dp-bolt",
 			"revision": "e6f3419169351b46a12d37087b4978f493f26a9f",
 			"revisionTime": "2018-07-11T08:29:42Z"
@@ -103,12 +103,6 @@
 			"path": "github.com/ONSdigital/go-ns/log",
 			"revision": "81b393bfc6e80674df603b7fde2f31a35e81b9dd",
 			"revisionTime": "2019-03-01T13:55:03Z"
-		},
-		{
-			"checksumSHA1": "L4B1AA6AKWscHCZc02qk2SQU65k=",
-			"path": "github.com/ONSdigital/go-ns/rchttp",
-			"revision": "1c0a788c5b8e666c674540fc0881960857d73b3b",
-			"revisionTime": "2019-01-17T11:52:14Z"
 		},
 		{
 			"checksumSHA1": "GQdzMpAMb42KQQ/GsJFSRU5dj1Y=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -171,10 +171,10 @@
 			"revisionTime": "2018-06-05T21:15:56Z"
 		},
 		{
-			"checksumSHA1": "Js/yx9fZ3+wH1wZpHNIxSTMIaCg=",
+			"checksumSHA1": "cIiyvAduLLFvu+tg1Qr5Jw3jeWo=",
 			"path": "github.com/jtolds/gls",
-			"revision": "77f18212c9c7edc9bd6a33d383a7b545ce62f064",
-			"revisionTime": "2017-05-03T22:40:06Z"
+			"revision": "b4936e06046bbecbb94cae9c18127ebe510a2cb9",
+			"revisionTime": "2018-11-10T20:28:10Z"
 		},
 		{
 			"checksumSHA1": "OBvAHqWjdI4NQVAqTkcQAdTuCFY=",
@@ -221,22 +221,22 @@
 			"revisionTime": "2018-06-07T16:21:44Z"
 		},
 		{
-			"checksumSHA1": "c71WVAQlpp3r4I+BtTxRz1Cq1Lw=",
+			"checksumSHA1": "clSz8OLgNZgATQ7mKB80ZRDdxDs=",
 			"path": "github.com/smartystreets/goconvey/convey",
-			"revision": "ef6db91d284a0e7badaa1f0c404c30aa7dee3aed",
-			"revisionTime": "2018-02-22T19:45:00Z"
+			"revision": "9d28bd7c0945047857c9740bd2eb3d62f98d3d35",
+			"revisionTime": "2019-07-10T18:59:42Z"
 		},
 		{
 			"checksumSHA1": "6Mgn4H/4vpqYGlaIKZ0UwOmJN0E=",
 			"path": "github.com/smartystreets/goconvey/convey/gotest",
-			"revision": "ef6db91d284a0e7badaa1f0c404c30aa7dee3aed",
-			"revisionTime": "2018-02-22T19:45:00Z"
+			"revision": "9d28bd7c0945047857c9740bd2eb3d62f98d3d35",
+			"revisionTime": "2019-07-10T18:59:42Z"
 		},
 		{
-			"checksumSHA1": "FWDhk37bhAwZ2363D/L2xePwR64=",
+			"checksumSHA1": "zUFddnpn7/A+gjwhShq642PM40I=",
 			"path": "github.com/smartystreets/goconvey/convey/reporting",
-			"revision": "ef6db91d284a0e7badaa1f0c404c30aa7dee3aed",
-			"revisionTime": "2018-02-22T19:45:00Z"
+			"revision": "9d28bd7c0945047857c9740bd2eb3d62f98d3d35",
+			"revisionTime": "2019-07-10T18:59:42Z"
 		},
 		{
 			"checksumSHA1": "GtamqiJoL7PGHsN454AoffBFMa8=",


### PR DESCRIPTION
### What

- go-ns/rchttp removed from vendors.json

- go-ns internally has dependencies with go-ns/rchttp, so it was not physically removed from vendors folder.

- no dependency found with go-ns/rchttp in the dp-code-list-api code.

### How to review

validated that the code builds, the unit tests pass, and the REST interface works.

> ➜  dp-code-list-api git:(feature/update-references-to-rchttp) ✗ make build
> go build -o build/darwin-amd64/./dp-code-list-api cmd/dp-code-list-api/main.go
> ➜  dp-code-list-api git:(feature/update-references-to-rchttp) ✗ make test
> go test -cover github.com/ONSdigital/dp-code-list-api/api github.com/ONSdigital/dp-code-list-api/cmd/dp-code-list-api github.com/ONSdigital/dp-code-list-api/config github.com/ONSdigital/dp-code-list-api/datastore github.com/ONSdigital/dp-code-list-api/datastore/datastoretest github.com/ONSdigital/dp-code-list-api/models
> ok  	github.com/ONSdigital/dp-code-list-api/api	(cached)	coverage: 60.3% of statements
> ?   	github.com/ONSdigital/dp-code-list-api/cmd/dp-code-list-api	[no test files]
> ok  	github.com/ONSdigital/dp-code-list-api/config	(cached)	coverage: 75.0% of statements
> ?   	github.com/ONSdigital/dp-code-list-api/datastore	[no test files]
> ?   	github.com/ONSdigital/dp-code-list-api/datastore/datastoretest	[no test files]
> ok  	github.com/ONSdigital/dp-code-list-api/models	(cached)	coverage: 11.5% of statements

### Who can review

anyone