### PR TITLE
Updated default healthcheck config and upgraded to latest dp-healthcheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ The endpoint `/health` checks the connection to the database and returns one of:
 
 ### Configuration
 
-| Environment variable          | Default                                | Description
+| Environment variable         | Default                                | Description
 | ---------------------------- | ---------------------------------------| -----------
 | BIND_ADDR                    | :22400                                 | The host and port to bind to
 | CODE_LIST_API_URL            | http://localhost:22400                 | The base URL for the code list API
 | DATASET_API_URL              | http://localhost:22000                 | The base URL for the dataset API
 | GRACEFUL_SHUTDOWN_TIMEOUT    | 5s                                     | The graceful shutdown timeout in seconds
-| HEALTHCHECK_INTERVAL         | 10s                                    | Time between calls to healthchecks
-| HEALTHCHECK_CRITICAL_TIMEOUT | 1m                                     | Timeout to consider a failing healthcheck critical
+| HEALTHCHECK_INTERVAL         | 30s                                    | Time between calls to healthchecks
+| HEALTHCHECK_CRITICAL_TIMEOUT | 90s                                    | Timeout to consider a failing healthcheck critical
 
 ### License
 

--- a/config/config.go
+++ b/config/config.go
@@ -28,8 +28,8 @@ func Get() (*Configuration, error) {
 		CodeListAPIURL:             "http://localhost:22400",
 		DatasetAPIURL:              "http://localhost:22000",
 		GracefulShutdownTimeout:    time.Second * 5,
-		HealthCheckInterval:        10 * time.Second,
-		HealthCheckCriticalTimeout: 1 * time.Minute,
+		HealthCheckInterval:        30 * time.Second,
+		HealthCheckCriticalTimeout: 90 * time.Second,
 	}
 
 	return cfg, envconfig.Process("", cfg)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -17,8 +17,8 @@ func TestGetReturnsDefaultValues(t *testing.T) {
 			CodeListAPIURL:             "http://localhost:22400",
 			DatasetAPIURL:              "http://localhost:22000",
 			GracefulShutdownTimeout:    time.Second * 5,
-			HealthCheckInterval:        time.Second * 10,
-			HealthCheckCriticalTimeout: time.Minute,
+			HealthCheckInterval:        time.Second * 30,
+			HealthCheckCriticalTimeout: time.Second * 90,
 		})
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/ONSdigital/dp-graph/v2 v2.0.3
-	github.com/ONSdigital/dp-healthcheck v1.0.2
+	github.com/ONSdigital/dp-healthcheck v1.0.3
 	github.com/ONSdigital/go-ns v0.0.0-20200205115900-a11716f93bad
 	github.com/ONSdigital/log.go v1.0.0
 	github.com/gorilla/mux v1.7.4

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/ONSdigital/dp-graph/v2 v2.0.3/go.mod h1:jh7BsDGMG0VgNtSvc3hlA2wXs3H1c
 github.com/ONSdigital/dp-healthcheck v0.0.0-20200131122546-9db6d3f0494e/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
 github.com/ONSdigital/dp-healthcheck v1.0.2 h1:N8SzpYzdixVgJS9NMzTBA2RZ2bi3Am1wE5F8ROEpTYw=
 github.com/ONSdigital/dp-healthcheck v1.0.2/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
+github.com/ONSdigital/dp-healthcheck v1.0.3 h1:wNA34U3uPD5t1SE8P3cbGqNZP4CUjyJFbSugPYgrBG0=
+github.com/ONSdigital/dp-healthcheck v1.0.3/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
 github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9/go.mod h1:BcIRgitUju//qgNePRBmNjATarTtynAgc0yV29VpLEk=
 github.com/ONSdigital/dp-rchttp v0.0.0-20190919143000-bb5699e6fd59/go.mod h1:KkW68U3FPuivW4ogi9L8CPKNj9ZxGko4qcUY7KoAAkQ=
 github.com/ONSdigital/dp-rchttp v0.0.0-20200114090501-463a529590e8/go.mod h1:821jZtK0oBsV8hjIkNr8vhAWuv0FxJBPJuAHa2B70Gk=


### PR DESCRIPTION
### What

Updated default healthcheck config values:
- HealthCheckInterval:        30 * time.Second (env `HEALTHCHECK_INTERVAL`)
- HealthCheckCriticalTimeout: 90 * time.Second (env `HEALTHCHECK_CRITICAL_TIMEOUT`)

### How to review

- Make sure the default config uses the expected values and env vars

### Who can review

Anyone.