### PR TITLE
Upgrade dp-graph to version 2.0.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ONSdigital/dp-code-list-api
 go 1.13
 
 require (
-	github.com/ONSdigital/dp-graph/v2 v2.0.3
+	github.com/ONSdigital/dp-graph/v2 v2.0.6
 	github.com/ONSdigital/dp-healthcheck v1.0.3
 	github.com/ONSdigital/go-ns v0.0.0-20200205115900-a11716f93bad
 	github.com/ONSdigital/log.go v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/ONSdigital/dp-api-clients-go v1.1.0/go.mod h1:9lqor0I7caCnRWr04gU/r7x5dqxgoODob8L48q+cE4E=
 github.com/ONSdigital/dp-frontend-models v1.1.0/go.mod h1:TT96P7Mi69N3Tc/jFNdbjiwG4GAaMjP26HLotFQ6BPw=
-github.com/ONSdigital/dp-graph/v2 v2.0.3 h1:7wnZH6TTve84jQjTl/hqQOh0BeWiYKRL33OKjr/+QXw=
-github.com/ONSdigital/dp-graph/v2 v2.0.3/go.mod h1:jh7BsDGMG0VgNtSvc3hlA2wXs3H1cwdWCp84VGzMVB8=
+github.com/ONSdigital/dp-graph/v2 v2.0.6 h1:1Y8mkDC0KgbZWHLmidYUckIFrZFStuW/wa81NprUxxk=
+github.com/ONSdigital/dp-graph/v2 v2.0.6/go.mod h1:jh7BsDGMG0VgNtSvc3hlA2wXs3H1cwdWCp84VGzMVB8=
 github.com/ONSdigital/dp-healthcheck v0.0.0-20200131122546-9db6d3f0494e/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
 github.com/ONSdigital/dp-healthcheck v1.0.2 h1:N8SzpYzdixVgJS9NMzTBA2RZ2bi3Am1wE5F8ROEpTYw=
 github.com/ONSdigital/dp-healthcheck v1.0.2/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=


### PR DESCRIPTION
Upgrade dp-graph to version 2.0.6

 - fixes codes endpoint not returning code labels when using Neptune