### PR TITLE
doc. explain the existence of 'Offset'

### DIFF
--- a/models/codelist.go
+++ b/models/codelist.go
@@ -9,11 +9,26 @@ import (
 
 // CodeListResults contains an array of code lists which can be paginated
 type CodeListResults struct {
-	Items      []CodeList `json:"items"`
-	Count      int        `json:"count"`
-	Offset     int        `json:"offset"`
-	Limit      int        `json:"limit"`
-	TotalCount int        `json:"total_count"`
+	Items []CodeList `json:"items"`
+	Count int        `json:"count"`
+
+	// Offset is a TODO for future use. Its use will be to do with pagination.
+	// It is intended to be used with the other structure members where:
+	//   Limit - max number of items we're returning in this response
+	//           (e.g. 20, or 50, rather than all we use atm)
+	//   Count - how many items are actually present in the response
+	//   TotalCount - how many total items there may be
+	//                (so the full list size, maybe thousands)
+	//   Offset - the number of documents into the full list that this
+	//            particular response is starting at.
+	//
+	// So in a list that has a totalCount of 511, we might set a limit of 100,
+	// an offset of 500, and get a response whose count is 11, because its the
+	// last 11 documents in the list.
+	Offset int `json:"offset"`
+
+	Limit      int `json:"limit"`
+	TotalCount int `json:"total_count"`
 }
 
 // CodeList containing links to all possible codes


### PR DESCRIPTION
Add comments to explain the intended use of the Offset struct member.

I've  taken Eleanor's explanation for the existence of the 'Offset' struct member and applied it as a comment in a style similar to that used in the golang libraries, for example:
https://github.com/golang/go/blob/2be7788f8383c2330cd96db53273e2995d4468f8/src/net/http/http.go#L129

