### PR TITLE
updated pagination to comply with new standards

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016-2020 Office for National Statistics
+Copyright (c) 2016-2021 Office for National Statistics
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ The endpoint `/health` checks the connection to the database and returns one of:
 | GRACEFUL_SHUTDOWN_TIMEOUT    | 5s                                     | The graceful shutdown timeout in seconds
 | HEALTHCHECK_INTERVAL         | 30s                                    | Time between calls to healthchecks
 | HEALTHCHECK_CRITICAL_TIMEOUT | 90s                                    | Timeout to consider a failing healthcheck critical
+| DEFAULT_MAXIMUM_LIMIT        | 1000                                   | Default maximum limit for pagination
+| DEFAULT_LIMIT                | 20                                     | Default limit for pagination
+| DEFAULT_OFFSET               | 0                                      | Default offset for pagination
 
 ### License
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,6 @@ The endpoint `/health` checks the connection to the database and returns one of:
 
 ### License
 
-Copyright © 2016-2017, Office for National Statistics (https://www.ons.gov.uk)
+Copyright © 2016-2021, Office for National Statistics (https://www.ons.gov.uk)
 
 Released under MIT license, see [LICENSE](LICENSE.md) for details

--- a/api/api.go
+++ b/api/api.go
@@ -72,13 +72,14 @@ func handleError(ctx context.Context, logMsg string, logData log.Data, err error
 
 // ValidatePositiveInt obtains the positive int value of query var defined by the provided varKey
 func ValidatePositiveInt(parameter string) (val int, err error) {
-	err = errors.New("value is not a positive integer")
 	val, err = strconv.Atoi(parameter)
+	errInvalid := errors.New("invalid query parameter")
+
 	if err != nil {
-		return -1, err
+		return -1, errInvalid
 	}
 	if val < 0 {
-		return -1, err
+		return -1, errInvalid
 	}
 	return val, nil
 }

--- a/api/api.go
+++ b/api/api.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ONSdigital/dp-graph/v2/graph/driver"
 	"github.com/ONSdigital/log.go/log"
 	"github.com/gorilla/mux"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -71,7 +72,7 @@ func handleError(ctx context.Context, logMsg string, logData log.Data, err error
 
 // ValidatePositiveInt obtains the positive int value of query var defined by the provided varKey
 func ValidatePositiveInt(parameter string) (val int, err error) {
-
+	err = errors.New("value is not a positive integer")
 	val, err = strconv.Atoi(parameter)
 	if err != nil {
 		return -1, err

--- a/api/api.go
+++ b/api/api.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"net/http"
-	"net/url"
 	"strconv"
 
 	"context"
@@ -28,10 +27,11 @@ type CodeListAPI struct {
 	datasetAPIURL string
 	defaultOffset int
 	defaultLimit  int
+	maxLimit      int
 }
 
 // CreateCodeListAPI returns a constructed code list api
-func CreateCodeListAPI(route *mux.Router, store datastore.DataStore, apiURL, datasetAPIURL string, defaultOffset, defaultLimit int) *CodeListAPI {
+func CreateCodeListAPI(route *mux.Router, store datastore.DataStore, apiURL, datasetAPIURL string, defaultOffset, defaultLimit, maxLimit int) *CodeListAPI {
 	api := CodeListAPI{
 		router:        route,
 		store:         store,
@@ -47,6 +47,7 @@ func CreateCodeListAPI(route *mux.Router, store datastore.DataStore, apiURL, dat
 		},
 		defaultOffset: defaultOffset,
 		defaultLimit:  defaultLimit,
+		maxLimit:      maxLimit,
 	}
 
 	api.router.HandleFunc("/code-lists", api.getCodeLists).Methods("GET")
@@ -68,18 +69,15 @@ func handleError(ctx context.Context, logMsg string, logData log.Data, err error
 	}
 }
 
-// GetPositiveIntQueryParameter obtains the positive int value of query var defined by the provided varKey
-func GetPositiveIntQueryParameter(queryVars url.Values, varKey string, defaultValue int) (val int, err error) {
-	strVal, found := queryVars[varKey]
-	if !found {
-		return defaultValue, nil
-	}
-	val, err = strconv.Atoi(strVal[0])
+// ValidatePositiveInt obtains the positive int value of query var defined by the provided varKey
+func ValidatePositiveInt(parameter string) (val int, err error) {
+
+	val, err = strconv.Atoi(parameter)
 	if err != nil {
 		return -1, err
 	}
 	if val < 0 {
-		return 0, nil
+		return -1, err
 	}
 	return val, nil
 }

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -19,7 +19,8 @@ const (
 	datasetEditionID            = "testDatasetEdition"
 	latestDatasetEditionVersion = 248
 	defaultOffset               = 0
-	defaultLimit                = 100
+	defaultLimit                = 20
+	maxLimit                    = 1000
 )
 
 // ErrInternal is the error returned by mocks to emulate an internal service error

--- a/api/codelists.go
+++ b/api/codelists.go
@@ -15,22 +15,38 @@ import (
 func (c *CodeListAPI) getCodeLists(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	filterBy := r.URL.Query().Get("type")
-
-	// get limit from query parameters, or default value
-	limit, err := GetPositiveIntQueryParameter(r.URL.Query(), "limit", c.defaultLimit)
-	if err != nil {
-		handleError(ctx, "failed to obtain a positive integer value for limit query parameter", log.Data{"limit": limit}, err, w)
-		return
-	}
-
-	// get offset from query parameters, or default value
-	offset, err := GetPositiveIntQueryParameter(r.URL.Query(), "offset", c.defaultOffset)
-	if err != nil {
-		handleError(ctx, "failed to obtain a positive integer value for offset query parameter", log.Data{"offset": offset}, err, w)
-		return
-	}
+	logData := log.Data{}
+	offsetParameter := r.URL.Query().Get("offset")
+	limitParameter := r.URL.Query().Get("limit")
+	offset := c.defaultOffset
+	limit := c.defaultLimit
+	var err error
 
 	log.Event(ctx, "attempting to get code lists", log.INFO, log.Data{"type": filterBy})
+
+	if offsetParameter != "" {
+		logData["offset"] = offsetParameter
+		offset, err = ValidatePositiveInt(offsetParameter)
+		if err != nil {
+			handleError(ctx, "failed to obtain a positive integer value for offset query parameter", log.Data{}, err, w)
+			return
+		}
+	}
+
+	if limitParameter != "" {
+		logData["limit"] = limitParameter
+		limit, err = ValidatePositiveInt(limitParameter)
+		if err != nil {
+			handleError(ctx, "failed to obtain a positive integer value for offset query parameter", log.Data{}, err, w)
+			return
+		}
+	}
+
+	if limit > c.maxLimit {
+		logData["max_limit"] = c.maxLimit
+		handleError(ctx, "limit is greater than the maximum allowed", log.Data{}, err, w)
+		return
+	}
 
 	dbCodeLists, err := c.store.GetCodeLists(r.Context(), filterBy)
 	if err != nil {
@@ -112,11 +128,11 @@ func (c *CodeListAPI) getCodeList(w http.ResponseWriter, r *http.Request) {
 
 func codelistsSlice(full []dbmodels.CodeList, offset, limit int) (sliced []dbmodels.CodeList) {
 	end := offset + limit
-	if limit == 0 || end > len(full) {
+	if end > len(full) {
 		end = len(full)
 	}
 
-	if offset > len(full) {
+	if offset > len(full) || limit == 0 {
 		return []dbmodels.CodeList{}
 	}
 	return full[offset:end]

--- a/api/codelists.go
+++ b/api/codelists.go
@@ -28,7 +28,8 @@ func (c *CodeListAPI) getCodeLists(w http.ResponseWriter, r *http.Request) {
 		logData["offset"] = offsetParameter
 		offset, err = ValidatePositiveInt(offsetParameter)
 		if err != nil {
-			handleError(ctx, "failed to obtain a positive integer value for offset query parameter", log.Data{}, err, w)
+			log.Event(ctx, "invalid query parameter: offset", log.ERROR, log.Error(err), logData)
+			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 	}
@@ -37,14 +38,17 @@ func (c *CodeListAPI) getCodeLists(w http.ResponseWriter, r *http.Request) {
 		logData["limit"] = limitParameter
 		limit, err = ValidatePositiveInt(limitParameter)
 		if err != nil {
-			handleError(ctx, "failed to obtain a positive integer value for offset query parameter", log.Data{}, err, w)
+			log.Event(ctx, "invalid query parameter: limit", log.ERROR, log.Error(err), logData)
+			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 	}
 
 	if limit > c.maxLimit {
 		logData["max_limit"] = c.maxLimit
-		handleError(ctx, "limit is greater than the maximum allowed", log.Data{}, err, w)
+		err = errors.New("limit is greater than the maximum allowed")
+		log.Event(ctx, "invalid query parameter: limit, maximum limit reached", log.ERROR, log.Error(err), logData)
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 

--- a/api/codelists_test.go
+++ b/api/codelists_test.go
@@ -90,6 +90,26 @@ func TestGetCodeLists(t *testing.T) {
 
 		validateBody(w.Body, &models.CodeListResults{}, &paginationTestOne)
 	})
+
+	Convey("When negative limit and offset query parameters are provided, then 400 status returned", t, func() {
+		r := httptest.NewRequest("GET", fmt.Sprintf("%s/code-lists?offset=-1&limit=-2", codeListURL), nil)
+		w := httptest.NewRecorder()
+
+		api := CreateCodeListAPI(mux.NewRouter(), &storetest.DataStoreMock{}, codeListURL, datasetURL, defaultOffset, defaultLimit, maxLimit)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusBadRequest)
+
+	})
+
+	Convey("When limit above default maximum is provided, then 400 status returned", t, func() {
+		r := httptest.NewRequest("GET", fmt.Sprintf("%s/code-lists?limit=1001", codeListURL), nil)
+		w := httptest.NewRecorder()
+
+		api := CreateCodeListAPI(mux.NewRouter(), &storetest.DataStoreMock{}, codeListURL, datasetURL, defaultOffset, defaultLimit, maxLimit)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusBadRequest)
+
+	})
 }
 
 func TestGetCodeList(t *testing.T) {

--- a/api/codelists_test.go
+++ b/api/codelists_test.go
@@ -33,7 +33,7 @@ var (
 		Items:      []models.CodeList{expectedCodeList},
 		Count:      1,
 		Offset:     0,
-		Limit:      100,
+		Limit:      20,
 		TotalCount: 1,
 	}
 
@@ -52,14 +52,6 @@ var (
 		Limit:      7,
 		TotalCount: 1,
 	}
-
-	paginationTestThree = models.CodeListResults{
-		Items:      []models.CodeList{expectedCodeList},
-		Count:      1,
-		Offset:     0,
-		Limit:      0,
-		TotalCount: 1,
-	}
 )
 
 func TestGetCodeLists(t *testing.T) {
@@ -75,7 +67,7 @@ func TestGetCodeLists(t *testing.T) {
 			},
 		}
 
-		api := CreateCodeListAPI(mux.NewRouter(), mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit)
+		api := CreateCodeListAPI(mux.NewRouter(), mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit, maxLimit)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 
@@ -92,28 +84,11 @@ func TestGetCodeLists(t *testing.T) {
 			},
 		}
 
-		api := CreateCodeListAPI(mux.NewRouter(), mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit)
+		api := CreateCodeListAPI(mux.NewRouter(), mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit, maxLimit)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 
 		validateBody(w.Body, &models.CodeListResults{}, &paginationTestOne)
-	})
-
-	Convey("When a negative limit and offset query parameters are provided, then return codelist information with offset and limit equal to zero", t, func() {
-		r := httptest.NewRequest("GET", fmt.Sprintf("%s/code-lists?offset=-1&limit=-7", codeListURL), nil)
-		w := httptest.NewRecorder()
-
-		mockDatastore := &storetest.DataStoreMock{
-			GetCodeListsFunc: func(ctx context.Context, filterBy string) (*dbmodels.CodeListResults, error) {
-				return &dbCodeListResults, nil
-			},
-		}
-
-		api := CreateCodeListAPI(mux.NewRouter(), mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusOK)
-
-		validateBody(w.Body, &models.CodeListResults{}, &paginationTestThree)
 	})
 }
 
@@ -131,7 +106,7 @@ func TestGetCodeList(t *testing.T) {
 			},
 		}
 
-		api := CreateCodeListAPI(mux.NewRouter(), mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit)
+		api := CreateCodeListAPI(mux.NewRouter(), mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit, maxLimit)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 
@@ -148,7 +123,7 @@ func TestGetCodeList(t *testing.T) {
 			},
 		}
 
-		api := CreateCodeListAPI(mux.NewRouter(), mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit)
+		api := CreateCodeListAPI(mux.NewRouter(), mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit, maxLimit)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 	})
@@ -163,7 +138,7 @@ func TestGetCodeList(t *testing.T) {
 			},
 		}
 
-		api := CreateCodeListAPI(mux.NewRouter(), mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit)
+		api := CreateCodeListAPI(mux.NewRouter(), mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit, maxLimit)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 	})

--- a/api/codes.go
+++ b/api/codes.go
@@ -31,7 +31,8 @@ func (c *CodeListAPI) getCodes(w http.ResponseWriter, r *http.Request) {
 		logData["offset"] = offsetParameter
 		offset, err = ValidatePositiveInt(offsetParameter)
 		if err != nil {
-			handleError(ctx, "failed to obtain a positive integer value for offset query parameter", log.Data{}, err, w)
+			log.Event(ctx, "invalid query parameter: offset", log.ERROR, log.Error(err), logData)
+			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 	}
@@ -40,14 +41,17 @@ func (c *CodeListAPI) getCodes(w http.ResponseWriter, r *http.Request) {
 		logData["limit"] = limitParameter
 		limit, err = ValidatePositiveInt(limitParameter)
 		if err != nil {
-			handleError(ctx, "failed to obtain a positive integer value for offset query parameter", log.Data{}, err, w)
+			log.Event(ctx, "invalid query parameter: limit", log.ERROR, log.Error(err), logData)
+			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 	}
 
 	if limit > c.maxLimit {
 		logData["max_limit"] = c.maxLimit
-		handleError(ctx, "limit is greater than the maximum allowed", log.Data{}, err, w)
+		err = errors.New("limit is greater than the maximum allowed")
+		log.Event(ctx, "invalid query parameter: limit, maximum limit reached", log.ERROR, log.Error(err), logData)
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 

--- a/api/codes_test.go
+++ b/api/codes_test.go
@@ -61,14 +61,6 @@ var (
 		Limit:      7,
 		TotalCount: 1,
 	}
-
-	codePaginationTestThree = models.CodeResults{
-		Items:      []models.Code{expectedCode},
-		Count:      1,
-		Offset:     0,
-		Limit:      0,
-		TotalCount: 1,
-	}
 )
 
 var failWriteBody = func(w http.ResponseWriter, bytes []byte) error {
@@ -87,7 +79,7 @@ func TestGetCodes_DatastoreError(t *testing.T) {
 
 		Convey("when getCodes is called", func() {
 			router := mux.NewRouter()
-			CreateCodeListAPI(router, mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit)
+			CreateCodeListAPI(router, mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit, maxLimit)
 			w := httptest.NewRecorder()
 			r := httptest.NewRequest(http.MethodGet, fmt.Sprintf("%s/code-lists/%s/editions/%s/codes", codeListURL, codeListID, editionID), nil)
 
@@ -115,7 +107,7 @@ func TestGetCodes_EditionNotFound(t *testing.T) {
 
 		Convey("when getCodes is called", func() {
 			router := mux.NewRouter()
-			CreateCodeListAPI(router, mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit)
+			CreateCodeListAPI(router, mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit, maxLimit)
 			w := httptest.NewRecorder()
 			r := httptest.NewRequest(http.MethodGet, fmt.Sprintf("%s/code-lists/%s/editions/%s/codes", codeListURL, codeListID, editionID), nil)
 
@@ -144,7 +136,7 @@ func TestGetCodes_WriteBodyError(t *testing.T) {
 		Convey("when getCodes is called", func() {
 			router := mux.NewRouter()
 
-			api := CreateCodeListAPI(router, mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit)
+			api := CreateCodeListAPI(router, mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit, maxLimit)
 			api.writeBody = failWriteBody
 
 			w := httptest.NewRecorder()
@@ -171,7 +163,7 @@ func TestGetCodes_Success(t *testing.T) {
 		}
 		expectedResult := models.CodeResults{
 			Count:      1,
-			Limit:      100,
+			Limit:      20,
 			TotalCount: 1,
 			Items:      []models.Code{expectedCode},
 		}
@@ -185,7 +177,7 @@ func TestGetCodes_Success(t *testing.T) {
 		Convey("when getCodes is called", func() {
 			router := mux.NewRouter()
 
-			CreateCodeListAPI(router, mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit)
+			CreateCodeListAPI(router, mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit, maxLimit)
 
 			w := httptest.NewRecorder()
 			r := httptest.NewRequest(http.MethodGet, fmt.Sprintf("%s/code-lists/%s/editions/%s/codes", codeListURL, codeListID, editionID), nil)
@@ -218,29 +210,13 @@ func TestGetCodes_Pagination(t *testing.T) {
 			},
 		}
 
-		api := CreateCodeListAPI(mux.NewRouter(), mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit)
+		api := CreateCodeListAPI(mux.NewRouter(), mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit, maxLimit)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 
 		validateBody(w.Body, &models.CodeResults{}, &codePaginationTestOne)
 	})
 
-	Convey("When a negative limit and offset query parameters are provided, then return codes information with offset and limit equal to zero", t, func() {
-		r := httptest.NewRequest("GET", fmt.Sprintf("%s/code-lists/%s/editions/%s/codes?offset=-1&limit=-7", codeListURL, codeListID, editionID), nil)
-		w := httptest.NewRecorder()
-
-		mockDatastore := &storetest.DataStoreMock{
-			GetCodesFunc: func(ctx context.Context, codeListID string, editionID string) (*dbmodels.CodeResults, error) {
-				return &dbCodeResults, nil
-			},
-		}
-
-		api := CreateCodeListAPI(mux.NewRouter(), mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusOK)
-
-		validateBody(w.Body, &models.CodeResults{}, &codePaginationTestThree)
-	})
 }
 
 func TestGetCode_Success(t *testing.T) {
@@ -254,7 +230,7 @@ func TestGetCode_Success(t *testing.T) {
 		Convey("when getCodes is called", func() {
 			router := mux.NewRouter()
 
-			CreateCodeListAPI(router, mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit)
+			CreateCodeListAPI(router, mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit, maxLimit)
 
 			w := httptest.NewRecorder()
 			r := httptest.NewRequest(http.MethodGet, fmt.Sprintf("%s/code-lists/%s/editions/%s/codes/%s", codeListURL, codeListID, editionID, codeID), nil)
@@ -285,7 +261,7 @@ func TestGetCode_DatastoreError(t *testing.T) {
 
 		Convey("when getCodes is called", func() {
 			router := mux.NewRouter()
-			CreateCodeListAPI(router, mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit)
+			CreateCodeListAPI(router, mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit, maxLimit)
 			w := httptest.NewRecorder()
 			r := httptest.NewRequest(http.MethodGet, fmt.Sprintf("%s/code-lists/%s/editions/%s/codes/%s", codeListURL, codeListID, editionID, codeID), nil)
 
@@ -314,7 +290,7 @@ func TestGetCode_EditionNotFound(t *testing.T) {
 
 		Convey("when getCodes is called", func() {
 			router := mux.NewRouter()
-			CreateCodeListAPI(router, mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit)
+			CreateCodeListAPI(router, mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit, maxLimit)
 			w := httptest.NewRecorder()
 			r := httptest.NewRequest(http.MethodGet, fmt.Sprintf("%s/code-lists/%s/editions/%s/codes/%s", codeListURL, codeListID, editionID, codeID), nil)
 
@@ -343,7 +319,7 @@ func TestGetCode_WriteBodyError(t *testing.T) {
 
 		Convey("when getCodes is called", func() {
 			router := mux.NewRouter()
-			api := CreateCodeListAPI(router, mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit)
+			api := CreateCodeListAPI(router, mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit, maxLimit)
 			api.writeBody = failWriteBody
 
 			w := httptest.NewRecorder()

--- a/api/codes_test.go
+++ b/api/codes_test.go
@@ -217,6 +217,26 @@ func TestGetCodes_Pagination(t *testing.T) {
 		validateBody(w.Body, &models.CodeResults{}, &codePaginationTestOne)
 	})
 
+	Convey("When negative limit and offset query parameters are provided, then 400 status returned", t, func() {
+		r := httptest.NewRequest("GET", fmt.Sprintf("%s/code-lists?offset=-1&limit=-2", codeListURL), nil)
+		w := httptest.NewRecorder()
+
+		api := CreateCodeListAPI(mux.NewRouter(), &storetest.DataStoreMock{}, codeListURL, datasetURL, defaultOffset, defaultLimit, maxLimit)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusBadRequest)
+
+	})
+
+	Convey("When limit above default maximum is provided, then 400 status returned", t, func() {
+		r := httptest.NewRequest("GET", fmt.Sprintf("%s/code-lists?limit=1001", codeListURL), nil)
+		w := httptest.NewRecorder()
+
+		api := CreateCodeListAPI(mux.NewRouter(), &storetest.DataStoreMock{}, codeListURL, datasetURL, defaultOffset, defaultLimit, maxLimit)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusBadRequest)
+
+	})
+
 }
 
 func TestGetCode_Success(t *testing.T) {

--- a/api/datasets.go
+++ b/api/datasets.go
@@ -31,7 +31,8 @@ func (c *CodeListAPI) getCodeDatasets(w http.ResponseWriter, r *http.Request) {
 		logData["offset"] = offsetParameter
 		offset, err = ValidatePositiveInt(offsetParameter)
 		if err != nil {
-			handleError(ctx, "failed to obtain a positive integer value for offset query parameter", log.Data{}, err, w)
+			log.Event(ctx, "invalid query parameter: offset", log.ERROR, log.Error(err), logData)
+			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 	}
@@ -40,14 +41,17 @@ func (c *CodeListAPI) getCodeDatasets(w http.ResponseWriter, r *http.Request) {
 		logData["limit"] = limitParameter
 		limit, err = ValidatePositiveInt(limitParameter)
 		if err != nil {
-			handleError(ctx, "failed to obtain a positive integer value for offset query parameter", log.Data{}, err, w)
+			log.Event(ctx, "invalid query parameter: limit", log.ERROR, log.Error(err), logData)
+			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 	}
 
 	if limit > c.maxLimit {
 		logData["max_limit"] = c.maxLimit
-		handleError(ctx, "limit is greater than the maximum allowed", log.Data{}, err, w)
+		err = errors.New("limit is greater than the maximum allowed")
+		log.Event(ctx, "invalid query parameter: limit, maximum limit reached", log.ERROR, log.Error(err), logData)
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 

--- a/api/datasets_test.go
+++ b/api/datasets_test.go
@@ -55,7 +55,7 @@ var (
 		Items:      []models.Dataset{expectedDataset},
 		Count:      1,
 		Offset:     0,
-		Limit:      100,
+		Limit:      20,
 		TotalCount: 1,
 	}
 
@@ -74,14 +74,6 @@ var (
 		Limit:      7,
 		TotalCount: 1,
 	}
-
-	datasetPaginationTestThree = models.Datasets{
-		Items:      []models.Dataset{expectedDataset},
-		Count:      1,
-		Offset:     0,
-		Limit:      0,
-		TotalCount: 1,
-	}
 )
 
 func TestGetCodeDatasets(t *testing.T) {
@@ -96,7 +88,7 @@ func TestGetCodeDatasets(t *testing.T) {
 			},
 		}
 
-		api := CreateCodeListAPI(mux.NewRouter(), mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit)
+		api := CreateCodeListAPI(mux.NewRouter(), mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit, maxLimit)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 
@@ -113,7 +105,7 @@ func TestGetCodeDatasets(t *testing.T) {
 			},
 		}
 
-		api := CreateCodeListAPI(mux.NewRouter(), mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit)
+		api := CreateCodeListAPI(mux.NewRouter(), mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit, maxLimit)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 	})
@@ -132,7 +124,7 @@ func TestGetCodeDatasets_Pagination(t *testing.T) {
 			},
 		}
 
-		api := CreateCodeListAPI(mux.NewRouter(), mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit)
+		api := CreateCodeListAPI(mux.NewRouter(), mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit, maxLimit)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 
@@ -149,27 +141,10 @@ func TestGetCodeDatasets_Pagination(t *testing.T) {
 			},
 		}
 
-		api := CreateCodeListAPI(mux.NewRouter(), mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit)
+		api := CreateCodeListAPI(mux.NewRouter(), mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit, maxLimit)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 
 		validateBody(w.Body, &models.Datasets{}, &datasetPaginationTestTwo)
-	})
-
-	Convey("When a negative limit and offset query parameters are provided, then return codes information with offset and limit equal to zero", t, func() {
-		r := httptest.NewRequest("GET", fmt.Sprintf("%s/code-lists/%s/editions/%s/codes/%s/datasets?offset=-1&limit=-7", codeListURL, codeListID, editionID, codeID), nil)
-		w := httptest.NewRecorder()
-
-		mockDatastore := &storetest.DataStoreMock{
-			GetCodeDatasetsFunc: func(ctx context.Context, codeListID string, edition string, code string) (*dbmodels.Datasets, error) {
-				return &dbDatasets, nil
-			},
-		}
-
-		api := CreateCodeListAPI(mux.NewRouter(), mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusOK)
-
-		validateBody(w.Body, &models.Datasets{}, &datasetPaginationTestThree)
 	})
 }

--- a/api/datasets_test.go
+++ b/api/datasets_test.go
@@ -147,4 +147,24 @@ func TestGetCodeDatasets_Pagination(t *testing.T) {
 
 		validateBody(w.Body, &models.Datasets{}, &datasetPaginationTestTwo)
 	})
+
+	Convey("When negative limit and offset query parameters are provided, then 400 status returned", t, func() {
+		r := httptest.NewRequest("GET", fmt.Sprintf("%s/code-lists?offset=-1&limit=-2", codeListURL), nil)
+		w := httptest.NewRecorder()
+
+		api := CreateCodeListAPI(mux.NewRouter(), &storetest.DataStoreMock{}, codeListURL, datasetURL, defaultOffset, defaultLimit, maxLimit)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusBadRequest)
+
+	})
+
+	Convey("When limit above default maximum is provided, then 400 status returned", t, func() {
+		r := httptest.NewRequest("GET", fmt.Sprintf("%s/code-lists?limit=1001", codeListURL), nil)
+		w := httptest.NewRecorder()
+
+		api := CreateCodeListAPI(mux.NewRouter(), &storetest.DataStoreMock{}, codeListURL, datasetURL, defaultOffset, defaultLimit, maxLimit)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusBadRequest)
+
+	})
 }

--- a/api/datasets_test.go
+++ b/api/datasets_test.go
@@ -74,6 +74,22 @@ var (
 		Limit:      7,
 		TotalCount: 1,
 	}
+
+	datasetPaginationTestThree = models.Datasets{
+		Items:      []models.Dataset{},
+		Count:      0,
+		Offset:     2,
+		Limit:      1,
+		TotalCount: 1,
+	}
+
+	datasetPaginationTestFour = models.Datasets{
+		Items:      []models.Dataset{expectedDataset},
+		Count:      1,
+		Offset:     0,
+		Limit:      20,
+		TotalCount: 1,
+	}
 )
 
 func TestGetCodeDatasets(t *testing.T) {
@@ -148,6 +164,40 @@ func TestGetCodeDatasets_Pagination(t *testing.T) {
 		validateBody(w.Body, &models.Datasets{}, &datasetPaginationTestTwo)
 	})
 
+	Convey("When offset value greater than count provided, then return zero items", t, func() {
+		r := httptest.NewRequest("GET", fmt.Sprintf("%s/code-lists/%s/editions/%s/codes/%s/datasets?offset=2&limit=1", codeListURL, codeListID, editionID, codeID), nil)
+		w := httptest.NewRecorder()
+
+		mockDatastore := &storetest.DataStoreMock{
+			GetCodeDatasetsFunc: func(ctx context.Context, codeListID string, edition string, code string) (*dbmodels.Datasets, error) {
+				return &dbDatasets, nil
+			},
+		}
+
+		api := CreateCodeListAPI(mux.NewRouter(), mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit, maxLimit)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusOK)
+
+		validateBody(w.Body, &models.Datasets{}, &datasetPaginationTestThree)
+	})
+
+	Convey("When no offset or limit value provided, then return codes information based on defaults", t, func() {
+		r := httptest.NewRequest("GET", fmt.Sprintf("%s/code-lists/%s/editions/%s/codes/%s/datasets", codeListURL, codeListID, editionID, codeID), nil)
+		w := httptest.NewRecorder()
+
+		mockDatastore := &storetest.DataStoreMock{
+			GetCodeDatasetsFunc: func(ctx context.Context, codeListID string, edition string, code string) (*dbmodels.Datasets, error) {
+				return &dbDatasets, nil
+			},
+		}
+
+		api := CreateCodeListAPI(mux.NewRouter(), mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit, maxLimit)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusOK)
+
+		validateBody(w.Body, &models.Datasets{}, &datasetPaginationTestFour)
+	})
+
 	Convey("When negative limit and offset query parameters are provided, then 400 status returned", t, func() {
 		r := httptest.NewRequest("GET", fmt.Sprintf("%s/code-lists?offset=-1&limit=-2", codeListURL), nil)
 		w := httptest.NewRecorder()
@@ -160,6 +210,16 @@ func TestGetCodeDatasets_Pagination(t *testing.T) {
 
 	Convey("When limit above default maximum is provided, then 400 status returned", t, func() {
 		r := httptest.NewRequest("GET", fmt.Sprintf("%s/code-lists?limit=1001", codeListURL), nil)
+		w := httptest.NewRecorder()
+
+		api := CreateCodeListAPI(mux.NewRouter(), &storetest.DataStoreMock{}, codeListURL, datasetURL, defaultOffset, defaultLimit, maxLimit)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusBadRequest)
+
+	})
+
+	Convey("When non-integer query parameter value provided, then 400 status returned", t, func() {
+		r := httptest.NewRequest("GET", fmt.Sprintf("%s/code-lists?offset=x&limit=y", codeListURL), nil)
 		w := httptest.NewRecorder()
 
 		api := CreateCodeListAPI(mux.NewRouter(), &storetest.DataStoreMock{}, codeListURL, datasetURL, defaultOffset, defaultLimit, maxLimit)

--- a/api/editions.go
+++ b/api/editions.go
@@ -29,7 +29,8 @@ func (c *CodeListAPI) getEditions(w http.ResponseWriter, r *http.Request) {
 		logData["offset"] = offsetParameter
 		offset, err = ValidatePositiveInt(offsetParameter)
 		if err != nil {
-			handleError(ctx, "failed to obtain a positive integer value for offset query parameter", log.Data{}, err, w)
+			log.Event(ctx, "invalid query parameter: offset", log.ERROR, log.Error(err), logData)
+			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 	}
@@ -38,14 +39,17 @@ func (c *CodeListAPI) getEditions(w http.ResponseWriter, r *http.Request) {
 		logData["limit"] = limitParameter
 		limit, err = ValidatePositiveInt(limitParameter)
 		if err != nil {
-			handleError(ctx, "failed to obtain a positive integer value for offset query parameter", log.Data{}, err, w)
+			log.Event(ctx, "invalid query parameter: limit", log.ERROR, log.Error(err), logData)
+			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 	}
 
 	if limit > c.maxLimit {
 		logData["max_limit"] = c.maxLimit
-		handleError(ctx, "limit is greater than the maximum allowed", log.Data{}, err, w)
+		err = errors.New("limit is greater than the maximum allowed")
+		log.Event(ctx, "invalid query parameter: limit, maximum limit reached", log.ERROR, log.Error(err), logData)
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 

--- a/api/editions_test.go
+++ b/api/editions_test.go
@@ -42,7 +42,7 @@ var (
 		Items:      []models.Edition{expectedEdition},
 		Count:      1,
 		Offset:     0,
-		Limit:      100,
+		Limit:      20,
 		TotalCount: 1,
 	}
 
@@ -61,14 +61,6 @@ var (
 		Limit:      7,
 		TotalCount: 1,
 	}
-
-	editionsPaginationTestThree = models.Editions{
-		Items:      []models.Edition{expectedEdition},
-		Count:      1,
-		Offset:     0,
-		Limit:      0,
-		TotalCount: 1,
-	}
 )
 
 func TestGetEditions(t *testing.T) {
@@ -83,7 +75,7 @@ func TestGetEditions(t *testing.T) {
 			},
 		}
 
-		api := CreateCodeListAPI(mux.NewRouter(), mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit)
+		api := CreateCodeListAPI(mux.NewRouter(), mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit, maxLimit)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 
@@ -100,7 +92,7 @@ func TestGetEditions(t *testing.T) {
 			},
 		}
 
-		api := CreateCodeListAPI(mux.NewRouter(), mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit)
+		api := CreateCodeListAPI(mux.NewRouter(), mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit, maxLimit)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 	})
@@ -115,7 +107,7 @@ func TestGetEditions(t *testing.T) {
 			},
 		}
 
-		api := CreateCodeListAPI(mux.NewRouter(), mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit)
+		api := CreateCodeListAPI(mux.NewRouter(), mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit, maxLimit)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 	})
@@ -132,7 +124,7 @@ func TestGetEdition(t *testing.T) {
 			},
 		}
 
-		api := CreateCodeListAPI(mux.NewRouter(), mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit)
+		api := CreateCodeListAPI(mux.NewRouter(), mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit, maxLimit)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 
@@ -149,7 +141,7 @@ func TestGetEdition(t *testing.T) {
 			},
 		}
 
-		api := CreateCodeListAPI(mux.NewRouter(), mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit)
+		api := CreateCodeListAPI(mux.NewRouter(), mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit, maxLimit)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusNotFound)
 	})
@@ -164,7 +156,7 @@ func TestGetEdition(t *testing.T) {
 			},
 		}
 
-		api := CreateCodeListAPI(mux.NewRouter(), mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit)
+		api := CreateCodeListAPI(mux.NewRouter(), mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit, maxLimit)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
 	})
@@ -183,7 +175,7 @@ func TestGetEditions_Pagination(t *testing.T) {
 			},
 		}
 
-		api := CreateCodeListAPI(mux.NewRouter(), mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit)
+		api := CreateCodeListAPI(mux.NewRouter(), mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit, maxLimit)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 
@@ -200,28 +192,11 @@ func TestGetEditions_Pagination(t *testing.T) {
 			},
 		}
 
-		api := CreateCodeListAPI(mux.NewRouter(), mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit)
+		api := CreateCodeListAPI(mux.NewRouter(), mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit, maxLimit)
 		api.router.ServeHTTP(w, r)
 		So(w.Code, ShouldEqual, http.StatusOK)
 
 		validateBody(w.Body, &models.Editions{}, &editionsPaginationTestTwo)
-	})
-
-	Convey("When a negative limit and offset query parameters are provided, then return codes information with offset and limit equal to zero", t, func() {
-		r := httptest.NewRequest("GET", fmt.Sprintf("%s/code-lists/%s/editions?offset=-1&limit=-7", codeListURL, codeListID), nil)
-		w := httptest.NewRecorder()
-
-		mockDatastore := &storetest.DataStoreMock{
-			GetEditionsFunc: func(ctx context.Context, f string) (*dbmodels.Editions, error) {
-				return &dbEditions, nil
-			},
-		}
-
-		api := CreateCodeListAPI(mux.NewRouter(), mockDatastore, codeListURL, datasetURL, defaultOffset, defaultLimit)
-		api.router.ServeHTTP(w, r)
-		So(w.Code, ShouldEqual, http.StatusOK)
-
-		validateBody(w.Body, &models.Editions{}, &editionsPaginationTestThree)
 	})
 
 }

--- a/api/editions_test.go
+++ b/api/editions_test.go
@@ -199,4 +199,24 @@ func TestGetEditions_Pagination(t *testing.T) {
 		validateBody(w.Body, &models.Editions{}, &editionsPaginationTestTwo)
 	})
 
+	Convey("When negative limit and offset query parameters are provided, then 400 status returned", t, func() {
+		r := httptest.NewRequest("GET", fmt.Sprintf("%s/code-lists?offset=-1&limit=-2", codeListURL), nil)
+		w := httptest.NewRecorder()
+
+		api := CreateCodeListAPI(mux.NewRouter(), &storetest.DataStoreMock{}, codeListURL, datasetURL, defaultOffset, defaultLimit, maxLimit)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusBadRequest)
+
+	})
+
+	Convey("When limit above default maximum is provided, then 400 status returned", t, func() {
+		r := httptest.NewRequest("GET", fmt.Sprintf("%s/code-lists?limit=1001", codeListURL), nil)
+		w := httptest.NewRecorder()
+
+		api := CreateCodeListAPI(mux.NewRouter(), &storetest.DataStoreMock{}, codeListURL, datasetURL, defaultOffset, defaultLimit, maxLimit)
+		api.router.ServeHTTP(w, r)
+		So(w.Code, ShouldEqual, http.StatusBadRequest)
+
+	})
+
 }

--- a/cmd/dp-code-list-api/main.go
+++ b/cmd/dp-code-list-api/main.go
@@ -67,7 +67,7 @@ func main() {
 	router := mux.NewRouter()
 	router.Path("/health").HandlerFunc(hc.Handler)
 
-	api.CreateCodeListAPI(router, datastore, cfg.CodeListAPIURL, cfg.DatasetAPIURL, cfg.DefaultOffset, cfg.DefaultLimit)
+	api.CreateCodeListAPI(router, datastore, cfg.CodeListAPIURL, cfg.DatasetAPIURL, cfg.DefaultOffset, cfg.DefaultLimit, cfg.DefaultMaxLimit)
 	httpServer := dphttp.NewServer(cfg.BindAddr, router)
 	httpServer.HandleOSSignals = false
 

--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,7 @@ type Configuration struct {
 	HealthCheckCriticalTimeout time.Duration `envconfig:"HEALTHCHECK_CRITICAL_TIMEOUT"`
 	DefaultLimit               int           `envconfig:"DEFAULT_LIMIT"`
 	DefaultOffset              int           `envconfig:"DEFAULT_OFFSET"`
+	DefaultMaxLimit            int           `envconfig:"DEFAULT_MAXIMUM_LIMIT"`
 }
 
 var cfg *Configuration
@@ -32,8 +33,9 @@ func Get() (*Configuration, error) {
 		GracefulShutdownTimeout:    time.Second * 5,
 		HealthCheckInterval:        30 * time.Second,
 		HealthCheckCriticalTimeout: 90 * time.Second,
-		DefaultLimit:               100,
+		DefaultLimit:               20,
 		DefaultOffset:              0,
+		DefaultMaxLimit:            1000,
 	}
 
 	return cfg, envconfig.Process("", cfg)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -20,7 +20,8 @@ func TestGetReturnsDefaultValues(t *testing.T) {
 			HealthCheckInterval:        time.Second * 30,
 			HealthCheckCriticalTimeout: time.Second * 90,
 			DefaultOffset:              0,
-			DefaultLimit:               100,
+			DefaultLimit:               20,
+			DefaultMaxLimit:            1000,
 		})
 	})
 }

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -36,7 +36,7 @@ parameters:
     required: true
   limit:
     name: limit
-    description: "Maximum number of items that will be returned. A value of zero will return zero items. The default value is 20."
+    description: "Maximum number of items that will be returned. A value of zero will return zero items. The default value is 20 and the maximum allowed is 1000."
     in: query
     required: false
     type: integer

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -34,6 +34,18 @@ parameters:
     in: path
     type: string
     required: true
+  limit:
+    name: limit
+    description: "Maximum number of items that will be returned. A value of zero will return zero items. The default value is 20."
+    in: query
+    required: false
+    type: integer
+  offset:
+    name: offset
+    description: "Starting index of the items array that will be returned. By default it is zero, meaning that the returned items will start from the beginning."
+    in: query
+    required: false
+    type: integer
 paths:
   /code-lists:
     get:
@@ -41,6 +53,9 @@ paths:
       - "Code List"
       summary: "Get a list of code lists"
       description: "Get a set of code lists containing information about dimensions which are used for all datasets at the ONS"
+      parameters:
+      - $ref: '#/parameters/limit'
+      - $ref: '#/parameters/offset'
       produces:
       - "application/json"
       responses:
@@ -79,6 +94,8 @@ paths:
       description: "Get a list of editions associated with a code list"
       parameters:
       - $ref: '#/parameters/id'
+      - $ref: '#/parameters/limit'
+      - $ref: '#/parameters/offset'
       produces:
       - "application/json"
       responses:
@@ -119,6 +136,8 @@ paths:
       parameters:
       - $ref: '#/parameters/id'
       - $ref: '#/parameters/edition'
+      - $ref: '#/parameters/limit'
+      - $ref: '#/parameters/offset'
       produces:
       - "application/json"
       responses:
@@ -161,6 +180,8 @@ paths:
       - $ref: '#/parameters/id'
       - $ref: '#/parameters/edition'
       - $ref: '#/parameters/codeId'
+      - $ref: '#/parameters/limit'
+      - $ref: '#/parameters/offset'
       produces:
       - "application/json"
       responses:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -40,12 +40,14 @@ parameters:
     in: query
     required: false
     type: integer
+    default: 20
   offset:
     name: offset
     description: "Starting index of the items array that will be returned. By default it is zero, meaning that the returned items will start from the beginning."
     in: query
     required: false
     type: integer
+    default: 0
 paths:
   /code-lists:
     get:


### PR DESCRIPTION
### What

Updated pagination to comply with the new API standards - https://github.com/ONSdigital/dp/blob/master/standards/API_STANDARDS.md 

- A limit of 0 now returns an empty list of items instead of all items
- The default limit has been set to 20
- Maximum limit has been set to 1000
- Negative values for offset and limit now result in an error
- Swagger spec and readme have been updated

### How to review

Confirm changes are correct

### Who can review

Anyone
