### PR TITLE
downgrade go version in ci files

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.20.5
+    tag: 1.20.4
 
 inputs:
   - name: dp-code-list-api

--- a/ci/component.yml
+++ b/ci/component.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.20.5
+    tag: 1.20.4
 
 inputs:
   - name: dp-code-list-api

--- a/ci/lint.yml
+++ b/ci/lint.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.20.5
+    tag: 1.20.4
 
 inputs:
   - name: dp-code-list-api

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.20.5
+    tag: 1.20.4
 
 inputs:
   - name: dp-code-list-api


### PR DESCRIPTION
### What

Downgrade the specified go version in the CI yml files to 1.20.4
Unable to deploy to sandbox, this is the current known solution

### How to review

Confirm that the files now use version 1.20.4

### Who can review

Anyone
